### PR TITLE
feat: Moving to 70 characters limit with a variable

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MeilleursAgents/ops

--- a/entrypoint
+++ b/entrypoint
@@ -57,7 +57,7 @@ git_is_conventional_commit() {
 }
 
 git_is_valid_description() {
-  if [[ ${1} =~ ^.{1,70}$ ]]; then
+  if [[ ${1} =~ ^.{1,${DESCRIPTION_MAX_LENGTH}}$ ]]; then
     printf "true"
   else
     printf "false"
@@ -67,6 +67,8 @@ git_is_valid_description() {
 main() {
   var_color
   git_conventionnal_commits
+
+  local DESCRIPTION_MAX_LENGTH="70"
 
   local BASE="${1:-master}"
   local HEAD="${2:-$(git rev-parse --abbrev-ref HEAD)}"
@@ -96,7 +98,7 @@ main() {
     fi
 
     if [[ $(git_is_valid_description "${commit}") != "true" ]]; then
-      printf "\t%btoo long, please reword below 70 characters%b\n" "${RED}" "${RESET}"
+      printf "\t%btoo long, please reword below %d characters%b\n" "${RED}" "${DESCRIPTION_MAX_LENGTH}" "${RESET}"
       UNCLEAR="true"
     fi
   done

--- a/tools/hooks/commit-msg
+++ b/tools/hooks/commit-msg
@@ -34,7 +34,7 @@ conventionnal_commit_guidelines() {
 }
 
 commit_message_guidelines() {
-  printf "\n%bYou have to use a short commit description (max 80 characters)%b\n\n" "${YELLOW}" "${RESET}"
+  printf "\n%bYou have to use a short commit description (max %d characters)%b\n\n" "${YELLOW}" "${DESCRIPTION_MAX_LENGTH}" "${RESET}"
 }
 
 git_is_commit_wip() {
@@ -65,7 +65,7 @@ git_is_conventional_commit() {
 }
 
 git_is_valid_description() {
-  if [[ ${1} =~ ^.{1,70}$ ]]; then
+  if [[ ${1} =~ ^.{1,${DESCRIPTION_MAX_LENGTH}}$ ]]; then
     printf "true"
   else
     printf "false"
@@ -75,6 +75,8 @@ git_is_valid_description() {
 main() {
   var_color
   git_conventionnal_commits
+
+  local DESCRIPTION_MAX_LENGTH="70"
 
   local FIRST_LINE
   FIRST_LINE="$(head -1 "${1}")"


### PR DESCRIPTION
```
macbook@macbook ~/code/JudCoCo (length_fixes) ✔
> git commit --allow-empty -m "this is a very long commit message that should not pass validation of the git commit hook"
Guidelines for prefixing commit message from conventionalcommits.org

chore(component):
        Changes in the core of the repository
fix(component):
        A bug fix for user (production change)
feat(component):
        A new feature for user (production change)
style(component):
        A change that do not affect the meaning of the code
refactor(component):
        A change that is not a feature not a bug (production change)
test(component):
        A new test or correcting existing tests
docs(component):
        Documentation only changes


You can add '!' before ':', for indicating breaking change

        feat(api)!: Adding mandatory parameter on signup

macbook@macbook ~/code/JudCoCo (length_fixes) x
> git commit --allow-empty -m "refactor: this is a very long commit message that should not pass validation of the git commit hook"

You have to use a short commit description (max 70 characters)
```