### PR TITLE
Features/support pre commit and improve hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,15 @@
+---
+
+- id: prepare-commit-msg
+  name: JudCoCo prepare
+  description: Use 'JudCoCo' help to write commit messages
+  entry: ./tools/hooks/prepare-commit-msg
+  language: script
+  stages: [prepare-commit-msg]
+
+- id: check-commit-msg
+  name: JudCoCo check
+  description: Run 'JudCoCo' for commit policy enforcement
+  entry: ./tools/hooks/commit-msg
+  language: script
+  stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -2,17 +2,15 @@
 
 Judge of Conventional Commit - Write better commit description
 
-## Inputs
 
-### `base`
+## Main script
 
-**Required** The base branch used for git comparison. Default `"master"`.
+### Inputs
 
-### `head`
+* `base`: **\[required\]** The base branch used for git comparison. Default `"master"`.
+* `head`: **\[required\]** The HEAD ref used for git comparison, you current branch
 
-**Required** The HEAD ref used for git comparison, you current branch
-
-## Example usage
+### Example usage as a Github action
 
 ```yaml
 ---
@@ -42,3 +40,33 @@ jobs:
           base: origin/${{ github.base_ref }}
           head: HEAD
 ```
+
+## Git hooks
+
+*JudCoCo* also provides git hooks for the best developer experience possible.
+
+### Example usage with [`pre-commit`](https://pre-commit.com/)
+
+Once you
+[have it installed](https://pre-commit.com/#install), add this to the
+`.pre-commit-config.yaml` file in your repository:
+
+```yaml
+# Make sure to set the default_stages in your config file
+# to prevent installing hooks multiple times inadvertently
+default_stages: [commit]
+
+repos:
+  - repo: https://github.com/MeilleursAgents/JudCoCo
+    # Replace by any tag/version: https://github.com/MeilleursAgents/JudCoCo/tags
+    rev: master
+    hooks:
+      # This hook will run during the 'commit-msg' stage
+      - id: check-commit-msg
+      # [Advance]: infer ticket number from branch name
+      # and add it to the commit message
+      # This hook will run during the 'prepare-commit-msg' stage
+      # - id: prepare-commit-msg
+```
+
+Then run `pre-commit install -t commit-msg [&& pre-commit install -t prepare-commit-msg]` and you're ready to go.

--- a/tools/hooks/commit-msg
+++ b/tools/hooks/commit-msg
@@ -88,7 +88,12 @@ handle_failed_check() {
     exit 0
   fi
 
-  printf '%b+-------------------------+\n| Commit has been aborted |\n+-------------------------+%b\n' "${RED}" "${RESET}"
+  printf '%b+------------------------------------------+\n| Commit has been aborted. Commit message: |%b\n' "${RED}" "${RESET}"
+
+  printf '%b+------------------------------------------+---------------------------+%b\n' "${RED}" "${RESET}"
+  printf "%s\n" "${COMMIT_MSG}"
+  printf '%b+----------------------------------------------------------------------+%b\n' "${RED}" "${RESET}"
+
   exit 1
 }
 
@@ -102,6 +107,9 @@ main() {
 
   local FIRST_LINE
   FIRST_LINE="$(head -1 "${1}")"
+
+  local COMMIT_MSG
+  COMMIT_MSG="$(cat "${1}")"
 
   if [[ $(git_is_commit_wip "${FIRST_LINE}") == "true" ]]; then
     exit 0

--- a/tools/hooks/commit-msg
+++ b/tools/hooks/commit-msg
@@ -84,7 +84,7 @@ git_is_safe_description() {
 }
 
 handle_failed_check() {
-  if [[ -z ${ENFORCE_CONVENTIONAL_COMMITS:-} ]]; then
+  if [[ ${ENFORCE_CONVENTIONAL_COMMITS:-true} != "true" ]]; then
     exit 0
   fi
 
@@ -95,6 +95,8 @@ handle_failed_check() {
 main() {
   var_color
   git_conventionnal_commits
+
+  local ENFORCE_CONVENTIONAL_COMMITS=${ENFORCE_CONVENTIONAL_COMMITS:-true}
 
   local DESCRIPTION_MAX_LENGTH="70"
 

--- a/tools/hooks/prepare-commit-msg
+++ b/tools/hooks/prepare-commit-msg
@@ -70,16 +70,20 @@ main() {
     exit 0
   fi
 
-  if [[ -n ${BRANCH_NAME} && ${BRANCH_NAME} =~ (feature|fixe)s?/([A-Z0-9]+[-_][0-9]+) ]]; then
-    local PREFIX="${BASH_REMATCH[2]}"
+  if [[ ! ${FIRST_LINE} =~ ([A-Z0-9]+[-_][0-9]+) ]]; then
 
-    if [[ ! ${FIRST_LINE} =~ ${PREFIX} ]]; then
-      if [[ $(git_is_conventional_commit "${FIRST_LINE}") == "true" ]]; then
-        perl -pi'' -e "s|^(revert:\ )?($(printf "%s\|" "${!CONVENTIONAL_COMMIT_SCOPES[@]}"))(\(.+\))?(\!?):|\1\2\3\4: ${PREFIX}|" "${1}"
-      else
-        sed_inplace -e "1s|^|${PREFIX} |" "${1}"
+    if [[ -n ${BRANCH_NAME} && ${BRANCH_NAME} =~ (feature|fixe)s?/([A-Z0-9]+[-_][0-9]+) ]]; then
+      local PREFIX="${BASH_REMATCH[2]}"
+
+      if [[ ! ${FIRST_LINE} =~ ${PREFIX} ]]; then
+        if [[ $(git_is_conventional_commit "${FIRST_LINE}") == "true" ]]; then
+          perl -pi'' -e "s|^(revert:\ )?($(printf "%s\|" "${!CONVENTIONAL_COMMIT_SCOPES[@]}"))(\(.+\))?(\!?):|\1\2\3\4: ${PREFIX}|" "${1}"
+        else
+          sed_inplace -e "1s|^|${PREFIX} |" "${1}"
+        fi
       fi
     fi
+
   fi
 
   exit 0


### PR DESCRIPTION
Hi there,

**The main objective of this PR it to add support for https://pre-commit.com/ to avoid copying / maintaining the hooks on each and every repo.**

Along the way, I have made the following tweaks to the hooks:

* for `prepare-commit-msg`, insert the ticket number from the branch only if a ticket number it's not already present in the commit's first line. This allow for a different ticket from the branch to be referenced in the commit,
* for `commit-msg`, default to `ENFORCE_CONVENTIONAL_COMMITS=true` (required for the `pre-commit` setup to work by default). And also print the commit message if it fails the check so it's easier to reuse it.

**To test:**
Follow the new instructions in the `README` ;) (for the `rev` value, you should use `features/support-pre-commit`) I am also available if any help is needed.
